### PR TITLE
Update README with EEA terms links

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 This repository uses Google Maps Platform services. Use of Google Maps Platform services through this library is subject to the Google Maps Platform [Terms of Service](https://cloud.google.com/maps-platform/terms).
 
+**European Economic Area (EEA) developers**
+
+If your billing address is in the European Economic Area, effective on 8 July 2025, the [Google Maps Platform EEA Terms of Service](https://cloud.google.com/terms/maps-platform/eea) will apply to your use of the Services. Functionality varies by region. [Learn more](https://developers.google.com/maps/comms/eea/faq).
+
 This repository is not a Google Maps Platform Core Service. Therefore, the Google Maps Platform Terms of Service (e.g. Technical Support Services, Service Level Agreements, and Deprecation Policy) do not apply to the code in this repository.
 
 ## Support


### PR DESCRIPTION
Adds links to Google Maps Platform European Economic Area (EEA) terms of service effective 8th July 2025.