### PR TITLE
chore: Add internal usage attribution ID to GooglePlacesDemo(SwiftUI)

### DIFF
--- a/GooglePlacesDemos/GooglePlacesDemos/GooglePlacesDemosApp.swift
+++ b/GooglePlacesDemos/GooglePlacesDemos/GooglePlacesDemosApp.swift
@@ -46,7 +46,7 @@ struct GooglePlacesDemosApp: App {
         }
         
         let _ = PlacesClient.provideAPIKey(apiKey)
-        
+        GMSServices.addInternalUsageAttributionID("gmp_git_iosplacessamples_v1.0.0")
         #if DEBUG
         print("Places SDK Licenses:\n\(PlacesClient.openSourceLicenseInfo)")
         #endif


### PR DESCRIPTION
### Summary
  - Add `GMSServices.addInternalUsageAttributionID("gmp_git_iosplacessamples_v1.0.0")` to GooglePlacesDemos app initialization

 ### Changes
  - Modified `GooglePlacesDemos/GooglePlacesDemos/GooglePlacesDemosApp.swift` to include internal usage attribution ID
  - Attribution ID is set after API key provision to enable tracking of Places SDK usage in sample apps