### PR TITLE
chore: Add internal usage attribution to GooglePlaces SDK Samples

### DIFF
--- a/Archive/GooglePlaces-Objc/GooglePlacesXCFrameworkDemos/DemoAppDelegate.m
+++ b/Archive/GooglePlaces-Objc/GooglePlacesXCFrameworkDemos/DemoAppDelegate.m
@@ -43,6 +43,7 @@
 
   // Provide the Places SDK with your API key.
   [GMSPlacesClient provideAPIKey:kAPIKey];
+  [GMSPlacesClient addInternalUsageAttributionID:@"gmp_git_iosplacesobjcsamples_v1.0.0"];
 
   // Log the required open source licenses! Yes, just NSLog-ing them is not enough but is good for a
   // demo.

--- a/GooglePlaces-Swift/GooglePlacesSwiftXCFrameworkDemos/Swift/AppDelegate.swift
+++ b/GooglePlaces-Swift/GooglePlacesSwiftXCFrameworkDemos/Swift/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelegate {
   ) -> Bool {
 
     GMSPlacesClient.provideAPIKey(apiKey)
-
+    GMSPlacesClient.addInternalUsageAttributionID("gmp_git_iosplacesswiftsamples_v1.0.0")
     // Log the required open source licenses! Yes, just NSLog-ing them is not enough but is good
     // for a demo.
     print("Google Places open source licenses:\n%@", GMSPlacesClient.openSourceLicenseInfo())

--- a/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos.xcodeproj/project.pbxproj
+++ b/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos.xcodeproj/project.pbxproj
@@ -14,9 +14,22 @@
 		9D064BCB2E44E9E0000F65EB /* GooglePlacesUIKitDemos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GooglePlacesUIKitDemos.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		3ECE7A342FD021A700EDC6B4 /* Exceptions for "GooglePlacesUIKitDemos" folder in "GooglePlacesUIKitDemos" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 9D064BCA2E44E9E0000F65EB /* GooglePlacesUIKitDemos */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		9D064BCD2E44E9E0000F65EB /* GooglePlacesUIKitDemos */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				3ECE7A342FD021A700EDC6B4 /* Exceptions for "GooglePlacesUIKitDemos" folder in "GooglePlacesUIKitDemos" target */,
+			);
 			path = GooglePlacesUIKitDemos;
 			sourceTree = "<group>";
 		};

--- a/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/GooglePlacesUIKitDemosApp.swift
+++ b/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/GooglePlacesUIKitDemosApp.swift
@@ -35,6 +35,7 @@ struct GooglePlacesUIKitDemosApp: App {
       fatalError("API_KEY not set in Info.plist")
     }
     let _ = PlacesClient.provideAPIKey(apiKey)
+    PlacesClient.addInternalUsageAttributionID("gmp_git_iosplacesuikitsamples_v1.0.0")
 
     // Log the required open source licenses! Yes, just NSLog-ing them is not enough but is good
     // for a demo.


### PR DESCRIPTION
### Summary
  - Add internal usage attribution ID to GooglePlacesUIKitDemos for tracking

 ### Changes
  - **Attribution**: Added `GMSServices.addInternalUsageAttributionID("gmp_git_iosplacesuikitsamples_v1.0.0")`
  - **Build Fix**: Added PBXFileSystemSynchronizedBuildFileExceptionSet to prevent Info.plist duplicate commands

 ### Technical Details
  - Uses modern `PBXFileSystemSynchronizedRootGroup` for automatic file management
  - `Info.plist` excluded from bundle resources via `membershipExceptions` to resolve build conflicts