### PR TITLE
ci: build via Secrets.xcconfig + keyless build check [2/8]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,22 @@ jobs:
           with:
             xcode-version: 'latest-stable'
 
+        - name: Verify keyless fresh-clone build (validates include-optional fallback)
+          run: |
+            set -o pipefail
+            # No Secrets.xcconfig exists yet: the tracked GooglePlacesDemos.xcconfig
+            # wrapper's `#include? "Secrets.xcconfig"` must let the build succeed
+            # without a key (the app fails only at launch, not at build time).
+            test ! -f GooglePlacesDemos/GooglePlacesDemos/Secrets.xcconfig
+            xcodebuild build -project GooglePlacesDemos/GooglePlacesDemos.xcodeproj \
+            -scheme GooglePlacesDemos \
+            -destination 'platform=iOS Simulator,OS=26.2,name=iPhone 17' | xcpretty
+
         - name: Build and Test ( iOS 26.2)
           run: |
             set -o pipefail
-            echo "Adding GooglePlacesDemos.xcconfig file with dummy API keys"
-            echo "PLACES_API_KEY = UI_TEST_DUMMY_KEY" > GooglePlacesDemos/GooglePlacesDemos/GooglePlacesDemos.xcconfig
-            echo "MAPS_API_KEY = UI_TEST_DUMMY_KEY" >> GooglePlacesDemos/GooglePlacesDemos/GooglePlacesDemos.xcconfig
+            echo "Adding Secrets.xcconfig with a dummy API key"
+            echo "PLACES_API_KEY = UI_TEST_DUMMY_KEY" > GooglePlacesDemos/GooglePlacesDemos/Secrets.xcconfig
 
             echo "Building and Testing"
             xcodebuild test -project GooglePlacesDemos/GooglePlacesDemos.xcodeproj \


### PR DESCRIPTION
### What
- CI writes a dummy `Secrets.xcconfig` (`PLACES_API_KEY` only) instead of the now-tracked `GooglePlacesDemos.xcconfig` wrapper.
- Adds a **keyless build step** that builds with no `Secrets.xcconfig` present - asserts the `#include?` fallback lets a fresh clone build.
- Drops the stale `MAPS_API_KEY` line.

### Why
- After #28, `GooglePlacesDemos.xcconfig` is a **tracked wrapper**, so CI must no longer overwrite it - the key now belongs in `Secrets.xcconfig`.
- CI should exercise both paths the new setup relies on: builds **without** a key (optional include) and builds + tests **with** one.
- `MAPS_API_KEY` no longer exists (Maps was removed).

### When
- Part of the API-key unification series **[2/8]**; follows **#28** (which added the wrapper, the launch guard, and the `.gitignore` change).
- Base: the feature branch (already contains #28). CI-only change - no app code.

### Testing
- CI green: keyless build succeeds, then dummy-key build + test succeeds.