### PR TITLE
feat(GooglePlacesUIKitDemos): API key via Secrets.xcconfig [3/8]

### DIFF
--- a/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos.xcconfig
+++ b/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos.xcconfig
@@ -1,0 +1,4 @@
+// Checked in. Do NOT put your API key here.
+// Create Secrets.xcconfig next to this file and add:
+//   PLACES_API_KEY = <your key>
+#include? "Secrets.xcconfig"

--- a/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/GooglePlacesUIKitDemosApp.swift
+++ b/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/GooglePlacesUIKitDemosApp.swift
@@ -18,21 +18,21 @@ import GooglePlacesSwift
 @main
 struct GooglePlacesUIKitDemosApp: App {
   init() {
-    guard let infoDictionary: [String: Any] = Bundle.main.infoDictionary else {
-      fatalError("Info.plist not found")
-    }
-    guard let apiKey: String = infoDictionary["API_KEY"] as? String else {
-      // To use GooglePlacesDemos, please register an API Key for your application. Your API Key
-      // should be kept private and not be checked in.
-      //
-      // Create an xcconfig file for your API key. By default the file should be named
-      // "GooglePlacesDemos.xcconfig" and be located at the same directory level as the demo
-      // application's "Info.plist" file. The contents of this file should contain at least a line
-      // like `API_KEY = <insert your API key here>`.
-      //
-      // See documentation on getting an API Key for your API Project here:
-      // https://developers.google.com/places/ios-sdk/start#get-key
-      fatalError("API_KEY not set in Info.plist")
+    // To use GooglePlacesUIKitDemos, please register an API Key for your application. Your API Key
+    // should be kept private and not be checked in.
+    //
+    // Create a "Secrets.xcconfig" file next to this app's "Info.plist" and add a line like
+    // `PLACES_API_KEY = <insert your API key here>`. It is git-ignored, so your key stays out of
+    // version control. (The tracked "GooglePlacesUIKitDemos.xcconfig" wrapper includes it.)
+    //
+    // See documentation on getting an API Key for your API Project here:
+    // https://developers.google.com/maps/documentation/places/ios-sdk/get-api-key
+    guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "PLACES_API_KEY") as? String,
+      !apiKey.isEmpty
+    else {
+      fatalError(
+        "Add PLACES_API_KEY to Secrets.xcconfig next to this app's Info.plist. "
+          + "Get a key at https://developers.google.com/maps/documentation/places/ios-sdk/get-api-key")
     }
     let _ = PlacesClient.provideAPIKey(apiKey)
     PlacesClient.addInternalUsageAttributionID("gmp_git_iosplacesuikitsamples_v1.0.0")

--- a/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/Info.plist
+++ b/GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>API_KEY</key>
-	<string>$(API_KEY)</string>
+	<key>PLACES_API_KEY</key>
+	<string>$(PLACES_API_KEY)</string>
 </dict>
 </plist>


### PR DESCRIPTION
### What
- Renames `API_KEY` -`PLACES_API_KEY` (Info.plist + app code) and adds an empty-string check.
- Reads the key via `Bundle.main.object(forInfoDictionaryKey:)`, failing closed with a message pointing at `Secrets.xcconfig`.
- Adds tracked `GooglePlacesUIKitDemos.xcconfig` wrapper (`#include? "Secrets.xcconfig"`).

### Why
- Unifies this app onto the same key mechanism as the rest of the series `API_KEY` was the odd-one-out name.
- Key stays in git-ignored `Secrets.xcconfig`; nothing sensitive in version control.

### When
- Series **[3/8]**; follows #28 (flagship + gitignore). 
- No `project.pbxproj` change
- UIKit already references its wrapper as base config.

## Testing
- Create `GooglePlacesUIKitDemos/GooglePlacesUIKitDemos/Secrets.xcconfig` with `PLACES_API_KEY = ...` app launches; remove it builds, fail-closed at launch.

https://github.com/user-attachments/assets/11535360-b609-4ffa-a1c9-68179c859df0

<img width="1724" height="1081" alt="Screenshot 2026-07-20 at 9 44 11 PM" src="https://github.com/user-attachments/assets/83e64e79-4f84-47ae-a0de-d475230b2a0a" />
